### PR TITLE
Adding support for mpOT.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Tracer Implementation
 
-A demo project that shows how to implement a tracer for the Liberty `opentracing-1.2` feature.
+A demo project that shows how to implement a tracer for the Liberty `opentracing-1.3` feature.
 Once implemented as an OSGI bundle, a tracer can be included as a user feature that will automatically
-pull the `opentracing-1.2` feature. 
+pull the `opentracing-1.3` feature. 
 
 Building this project relies on the `bnd-process` plugin to process the `bnd.bnd` file which will generate
 the `MANIFEST.MF` to be included in the project. Additionally, annotations found in the [OpentracingZipkinTracerFactory.java](src/main/java/com/ibm/ws/opentracing/zipkin/OpentracingZipkinTracerFactory.java)
@@ -15,12 +15,12 @@ To compile and package, run:
 
     mvn package
 
-This will build `target/liberty-opentracing-zipkintracer-1.2-sample.zip`. Copy this file to `${wlp.user.dir}`
+This will build `target/liberty-opentracing-zipkintracer-1.3-sample.zip`. Copy this file to `${wlp.user.dir}`
 and `unzip` it to install the feature extension:
 
-    $ cp target/liberty-opentracing-zipkintracer-1.2-sample.zip ${WLP}/usr/
+    $ cp target/liberty-opentracing-zipkintracer-1.3-sample.zip ${WLP}/usr/
     $ cd ${WLP}/usr/
-    $ unzip liberty-opentracing-zipkintracer-1.2-sample.zip
+    $ unzip liberty-opentracing-zipkintracer-1.3-sample.zip
     $ ls -R extension/
     extension/:
     lib

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,14 +1,14 @@
 Bundle-SymbolicName: com.ibm.ws.opentracing.zipkin
 Bundle-Name: Opentracing Zipkin
-Bundle-Description: Opentracing Zipkin Factory Implemention; version=1.2
+Bundle-Description: Opentracing Zipkin Factory Implemention; version=1.3
 Bundle-ManifestVersion: 2
-Bundle-Version: 1.2
+Bundle-Version: 1.3
 
 -dsannotations: com.ibm.ws.opentracing.zipkin.OpentracingZipkinTracerFactory 
 
 Import-Package: com.ibm.ws.opentracing.tracer;version="[1.1,2)",io.opentracing;version="[0.31,1)", \
  io.opentracing.propagation;version="[0.31,1)",io.opentracing.tag;version="0.31.0",javax.net.ssl,javax.net,org.osgi.service.component
-Export-Package: com.ibm.ws.opentracing.zipkin;version="1.2.0";uses:="com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation"
+Export-Package: com.ibm.ws.opentracing.zipkin;version="1.3.0";uses:="com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation"
 
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"
 

--- a/src/features/opentracingZipkin-0.31.mf
+++ b/src/features/opentracingZipkin-0.31.mf
@@ -1,7 +1,7 @@
 IBM-Feature-Version: 2
 IBM-ShortName: opentracingZipkin-0.31
-Subsystem-Content: com.ibm.websphere.appserver.opentracing-1.1; ibm.tolerates:="1.2"; type="osgi.subsystem.feature",
- com.ibm.ws.opentracing.zipkin; version="[1.2.0,1.2.200)",
+Subsystem-Content: com.ibm.websphere.appserver.opentracing-1.1; ibm.tolerates:="1.2,1.3"; type="osgi.subsystem.feature",
+ com.ibm.ws.opentracing.zipkin; version="[1.3.0,1.3.200)",
  com.ibm.websphere.appserver.jaxrs-2.0; type="osgi.subsystem.feature"; ibm.tolerates:=2.1,
  com.ibm.websphere.appserver.cdi-1.2; type="osgi.subsystem.feature"; ibm.tolerates:=2.0
 Subsystem-Description: %description


### PR DESCRIPTION
Adding support for the MicroProfile OpenTracing 1.3 feature in Open Liberty.

For issue #19 